### PR TITLE
Add setup.py to project

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,65 @@
+import os.path
+from setuptools import find_packages, setup
+
+# Package data
+# ------------
+_author       = 'covjson'
+_authorEmail  = 'resc@reading.ac.uk'
+_classifiers  = [
+    'Environment :: Console',
+    'Intended Audience :: Developers',
+    'Intended Audience :: Information Technology',
+    'Intended Audience :: Science/Research',
+    'Topic :: Scientific/Engineering',
+    'Development Status :: 4 - Beta',
+    'License :: Copyright :: University of Reading',
+    'Operating System :: OS Independent',
+    'Programming Language :: Python',
+    'Topic :: Internet :: WWW/HTTP',
+    'Topic :: Software Development :: Libraries :: Python Modules',
+]
+_description  = 'Create CovJSON files from common scientific data formats'
+_downloadURL  = 'http://pypi.python.org/pypi/pycovjson/'
+_requirements = ["", "",""]
+_keywords     = ['dataset', 'coverage', 'covjson']
+_license      = 'Copyright :: University of Reading'
+_long_description    = 'A python utility library for creating CovJSON files from common scientific data formats'
+_name         = 'pycovjson'
+_namespaces   = []
+_testSuite    = 'pycovjson.test'
+_url          = 'https://github.com/Reading-eScience-Centre/pycovjson'
+_version      = '1.0.0'
+_zipSafe      = True
+
+# Setup Metadata
+# --------------
+
+def _read(*rnames):
+    return open(os.path.join(os.path.dirname(__file__), *rnames)).read()
+
+_header = '*' * len(_name) + '\n' + _name + '\n' + '*' * len(_name)
+_longDescription = '\n\n'.join([
+    _header,
+    _read('README.md')
+])
+open('doc.txt', 'w').write(_longDescription)
+
+setup(
+    author=_author,
+    author_email=_authorEmail,
+    classifiers=_classifiers,
+    description=_description,
+    download_url=_downloadURL,
+    include_package_data=True,
+    install_requires=_requirements,
+    keywords=_keywords,
+    license=_license,
+    long_description=_longDescription,
+    name=_name,
+    namespace_packages=_namespaces,
+    packages=find_packages(),
+    test_suite=_testSuite,
+    url=_url,
+    version=_version,
+    zip_safe=_zipSafe,
+)


### PR DESCRIPTION
@guygriffiths @jonblower this PR lacks the requirements as per
https://github.com/Reading-eScience-Centre/pycovjson/compare/master...lewismc:ISSUE-5?expand=1#diff-2eeaed663bd0d25b7e608891384b7298R23
If someone can add the dependencies then it can be merged and used to install and test the library locally. It can also be used to publish the library to Pypi when it is in a stable state.
