### PR TITLE
ISSUE-45 Implement exception handling for time object conversions

### DIFF
--- a/pycovjson/read_netcdf.py
+++ b/pycovjson/read_netcdf.py
@@ -311,8 +311,11 @@ class NetCDFReader(object):
         times = self.dataset[t_variable].values
 
         for time in times:
-            time = pd.to_datetime(str(time))
-            date_list.append(time.strftime('%Y-%m-%dT%H:%M:%SZ'))
+            try:
+                time = pd.to_datetime(str(time))
+                date_list.append(time.strftime('%Y-%m-%dT%H:%M:%SZ'))
+            except ValueError as ve:
+                print("Error parsing and converting '%s' variable object to CovJSON compliant string."  % (t_variable), ve)
 
         return date_list
 


### PR DESCRIPTION
This issue addresses #45. The new behavior is as follows
```
lmcgibbn@LMC-056430 /usr/local/pycovjson(ISSUE-42) $ pycovjson-convert -i SSS_OI_7D_20151482015154_V40.nc -o SSS_OI_7D_20151482015154_V40.nc_sss.covjson -v sss
Error in sitecustomize; set PYTHONVERBOSE for traceback:
KeyError: 'PYTHONPATH'
Failed to decode times encoded in the standard NetCDF datetime format into datetime objects. Attempting less strict opening logic. Reason:  unable to decode time units 'Julian days since December 31, 2010' with the default calendar. Try opening your dataset with decode_times=False.
Successfully opened dataset with less strict logic.
Error: DataArray does not include 'standard name' or 'name'.
Error: DataArray does not include 'standard name' or 'name'.
Error: DataArray does not include 'standard name' or 'name'.
Error: DataArray does not include 'standard name' or 'name'.
Error: DataArray does not include 'standard name' or 'name'.
Error: DataArray does not include 'standard name' or 'name'.
Error: DataArray does not include 'standard name' or 'name'.
Error: DataArray does not include 'standard name' or 'name'.
Error: DataArray does not include 'standard name' or 'name'.
Error parsing and converting 'time' variable object to CovJSON compliant string.  Unknown string format
Constructing Range from variable: sss
Variable 'sss' has no axis attribute, executing fallback for manual axis value detection.
Error: DataArray does not include 'standard name' or 'name'.
Error: DataArray does not include 'standard name' or 'name'.
Error: DataArray does not include 'standard name' or 'name'.
Manually detected axis as: '['t', 'y', 'x']'
Variable 'sss' has no axis attribute, executing fallback for manual axis value detection.
Error: DataArray does not include 'standard name' or 'name'.
Error: DataArray does not include 'standard name' or 'name'.
Error: DataArray does not include 'standard name' or 'name'.
Manually detected axis as: '['t', 'y', 'x']'
Attempting to write CovJSON manifestation to 'SSS_OI_7D_20151482015154_V40.nc_sss.covjson'
Completed in: '0.11765500000000007' seconds.
```
So although this product is still _messy_, we do provide the flexibility to successfully execute a conversion.